### PR TITLE
feat: basic play grid rendering implementation

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,8 @@
+import { PlayArea } from '@widgets'
+
 const App: FC = () => (
   <div className="mx-auto max-w-max">
-    <h1 className="tracking-widest text-center w-full text-4xl">ANOMASWPR</h1>
+    <PlayArea />
   </div>
 )
 

--- a/src/entities/grid/constants.ts
+++ b/src/entities/grid/constants.ts
@@ -1,0 +1,25 @@
+export const CELL_SIZE = {
+  min: 24,
+  max: 32,
+} as const // px
+
+export const CELL_VIEWPORT = {
+  gap: {
+    outter: 2,
+    inner: 1,
+  },
+  border: 1,
+} as const // px
+
+export const GRID_SIZE = {
+  rows: 15,
+  cols: 30,
+} as const
+
+export const GRID_VIEWPORT = {
+  gap: {
+    outter: 16,
+    inner: 2,
+  },
+  border: 1,
+} as const // px

--- a/src/entities/grid/helpers/calcGridBounds.ts
+++ b/src/entities/grid/helpers/calcGridBounds.ts
@@ -1,0 +1,61 @@
+import {
+  CELL_SIZE,
+  CELL_VIEWPORT,
+  GRID_SIZE,
+  GRID_VIEWPORT,
+} from '../constants'
+import { TGridBounds } from '../types'
+
+export const calcGridBounds = (): TGridBounds => {
+  const viewport = document.body.getBoundingClientRect()
+  const grid: TGridBounds = {
+    cell: CELL_SIZE.min,
+    gutter: {
+      inner: GRID_VIEWPORT.gap.inner * 2 + GRID_VIEWPORT.border * 2,
+      outter: GRID_VIEWPORT.gap.outter * 2,
+      full: 0,
+    },
+    width: {
+      full: 0,
+      visible: 0,
+    },
+    height: {
+      full: 0,
+      visible: 0,
+    },
+  }
+
+  grid.gutter.full = grid.gutter.inner + grid.gutter.outter
+  grid.width.full = viewport.width - grid.gutter.full
+  grid.height.full = viewport.height - grid.gutter.full
+
+  const isLandscapeView = grid.width.full > grid.height.full
+
+  grid.cell = Math.max(
+    CELL_SIZE.min,
+    Math.min(
+      CELL_SIZE.max,
+      Math.ceil(
+        isLandscapeView
+          ? grid.width.full / GRID_SIZE.cols
+          : grid.height.full / GRID_SIZE.rows
+      ) +
+        CELL_VIEWPORT.border * 2 +
+        CELL_VIEWPORT.gap.outter * 2
+    )
+  )
+
+  const cols = Math.floor(grid.width.full / grid.cell)
+  const rows = Math.floor(grid.height.full / grid.cell)
+
+  grid.width.visible =
+    grid.cell * (cols > GRID_SIZE.cols ? GRID_SIZE.cols : cols) +
+    grid.gutter.inner
+  grid.height.visible =
+    grid.cell * (rows > GRID_SIZE.rows ? GRID_SIZE.rows : rows) +
+    grid.gutter.inner * 2
+  grid.width.full = grid.cell * GRID_SIZE.cols + grid.gutter.inner
+  grid.height.full = grid.cell * GRID_SIZE.rows + grid.gutter.inner
+
+  return grid
+}

--- a/src/entities/grid/helpers/index.ts
+++ b/src/entities/grid/helpers/index.ts
@@ -1,0 +1,1 @@
+export { calcGridBounds } from './calcGridBounds'

--- a/src/entities/grid/hooks/index.ts
+++ b/src/entities/grid/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useGrid } from './useGrid.hook'

--- a/src/entities/grid/hooks/useGrid.hook.ts
+++ b/src/entities/grid/hooks/useGrid.hook.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useWindowResize } from '@shared'
+import { GRID_SIZE } from '../constants'
+import { calcGridBounds } from '../helpers'
+import { TGrid } from '../types'
+
+export const useGrid = (): TGrid => {
+  const [bounds, setBounds] = useState<TGrid['bounds']>(calcGridBounds())
+  const [cells, setCells] = useState<TGrid['cells']>([])
+
+  const handleWindowResize = useCallback(() => {
+    setBounds(calcGridBounds())
+  }, [])
+
+  useWindowResize(handleWindowResize)
+
+  useEffect(() => {
+    setCells(
+      [...new Array(GRID_SIZE.cols * GRID_SIZE.rows)].map((_, idx) => ({
+        id: idx,
+        position: {
+          col: idx % GRID_SIZE.cols,
+          row: idx % GRID_SIZE.rows,
+        },
+      }))
+    )
+  }, [])
+
+  return {
+    bounds,
+    cells,
+  }
+}

--- a/src/entities/grid/index.ts
+++ b/src/entities/grid/index.ts
@@ -1,0 +1,1 @@
+export { Grid } from './ui'

--- a/src/entities/grid/types.ts
+++ b/src/entities/grid/types.ts
@@ -1,0 +1,29 @@
+export type TCell = {
+  id: number
+  position: {
+    col: number
+    row: number
+  }
+}
+
+export type TGridBounds = {
+  cell: number
+  gutter: {
+    inner: number
+    outter: number
+    full: number
+  }
+  width: {
+    full: number
+    visible: number
+  }
+  height: {
+    full: number
+    visible: number
+  }
+} // px
+
+export type TGrid = {
+  bounds: TGridBounds
+  cells: TCell[]
+}

--- a/src/entities/grid/ui/Cell.module.css
+++ b/src/entities/grid/ui/Cell.module.css
@@ -1,0 +1,23 @@
+.container {
+  width: var(--cell-size);
+  height: var(--cell-size);
+  padding: var(--cell-margin);
+  box-sizing: border-box;
+}
+
+.content {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  box-shadow: inset 0px 0px 0px 1px var(--color-black) ;
+  background-color: transparent;
+  cursor: pointer;
+  transform: scale(1);
+  transition: transform 0.3s ease-out, background-color 0.5s;
+}
+
+.content:hover {
+  background-color: var(--color-gray-100);
+  transform: scale(0.96);
+}

--- a/src/entities/grid/ui/Cell.tsx
+++ b/src/entities/grid/ui/Cell.tsx
@@ -1,0 +1,8 @@
+import { TCell } from '../types'
+import cssModule from './Cell.module.css'
+
+export const Cell: FC<{ cell: TCell }> = () => (
+  <div className={cssModule.container}>
+    <div className={cssModule.content} />
+  </div>
+)

--- a/src/entities/grid/ui/Grid.module.css
+++ b/src/entities/grid/ui/Grid.module.css
@@ -1,0 +1,23 @@
+@keyframes faded-xy-slide {
+  0% {
+    background-color: var(--color-gray-100);
+    opacity: 1;
+    transform: translate(8px, 8px);
+  }
+  100% {
+    background-color: var(--color-white);
+    opacity: 0.5;
+    transform: translate(12px, 12px);
+  }
+}
+
+.floatedUnderlayer {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  transform: translate(8px, 8px);
+  opacity: 1;
+	animation: 3s faded-xy-slide ease-in infinite alternate-reverse both;
+}

--- a/src/entities/grid/ui/Grid.tsx
+++ b/src/entities/grid/ui/Grid.tsx
@@ -1,0 +1,48 @@
+import clsx from 'clsx'
+import { CSSProperties } from 'react'
+import { CELL_VIEWPORT, GRID_VIEWPORT } from '../constants'
+import { useGrid } from '../hooks'
+import { Cell } from './Cell'
+import cssModule from './Grid.module.css'
+
+export const Grid: FC = () => {
+  const grid = useGrid()
+
+  return (
+    <div
+      className="relative min-w-max min-h-max"
+      style={{
+        margin: GRID_VIEWPORT.gap.outter,
+      }}
+    >
+      <div
+        className="relative z-10 border rounded-lg overflow-hidden bg-white box-border"
+        style={
+          {
+            '--cell-size': `${grid.bounds.cell}px`,
+            '--cell-margin': `${CELL_VIEWPORT.gap.outter}px`,
+            '--cell-padding': `${CELL_VIEWPORT.gap.inner}px`,
+            '--cell-border-width': `${CELL_VIEWPORT.border}px`,
+            width: grid.bounds.width.visible,
+            height: grid.bounds.height.visible,
+            padding: GRID_VIEWPORT.gap.inner,
+            borderWidth: GRID_VIEWPORT.border,
+          } as CSSProperties
+        }
+      >
+        <div
+          className="w-full h-full flex flex-wrap box-border"
+          style={{
+            width: grid.bounds.width.full,
+            height: grid.bounds.height.full,
+          }}
+        >
+          {grid.cells.map((cell) => (
+            <Cell key={`cell-${cell.id}`} cell={cell} />
+          ))}
+        </div>
+      </div>
+      <div className={clsx(cssModule.floatedUnderlayer, 'border rounded-lg')} />
+    </div>
+  )
+}

--- a/src/entities/grid/ui/index.tsx
+++ b/src/entities/grid/ui/index.tsx
@@ -1,0 +1,1 @@
+export * from './Grid'

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -1,0 +1,1 @@
+export * from './grid'

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useWindowResize } from './useWindowResize.hook'

--- a/src/shared/hooks/useWindowResize.hook.ts
+++ b/src/shared/hooks/useWindowResize.hook.ts
@@ -1,0 +1,9 @@
+import { useEffect } from 'react'
+
+export function useWindowResize(callback: () => void): void {
+  useEffect(() => {
+    window.addEventListener('resize', callback)
+
+    return () => window.removeEventListener('resize', callback)
+  }, [callback])
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,0 +1,1 @@
+export * from './hooks'

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -1,0 +1,1 @@
+export * from './playarea'

--- a/src/widgets/playarea/PlayArea.tsx
+++ b/src/widgets/playarea/PlayArea.tsx
@@ -1,0 +1,7 @@
+import { Grid } from '@entities'
+
+export const PlayArea: FC = () => (
+  <>
+    <Grid />
+  </>
+)

--- a/src/widgets/playarea/index.tsx
+++ b/src/widgets/playarea/index.tsx
@@ -1,0 +1,1 @@
+export { PlayArea } from './PlayArea'


### PR DESCRIPTION
Implemented basic responsive play grid rendering with some initial UI

<p align="center">
  <img width="725" alt="responsive play grid" src="https://github.com/user-attachments/assets/8a07347f-0401-408e-b5b1-963055b1a76d" />
</p>

**P.S.** 30x15 default grid size is from "Expert" difficulty level from [minesweeper.online](https://minesweeper.online/)